### PR TITLE
Add no-dim version of simd_reduce_sum/mean

### DIFF
--- a/mx/simd_ops.py
+++ b/mx/simd_ops.py
@@ -505,19 +505,31 @@ def simd_log(in1, mx_specs=None):
     return SIMDLog.apply(in1, mx_specs)
 
 
-def simd_reduce_sum(in1, dim, keepdim=False, mx_specs=None):
+def simd_reduce_sum(in1, dim=None, keepdim=False, mx_specs=None):
     mx_assert_test(mx_specs)
     if mx_specs is None:
-        return torch_sum(in1, dim, keepdim=keepdim)
+        if dim is None:
+            return torch_sum(in1)
+        else:
+            return torch_sum(in1, dim, keepdim=keepdim)
+
+    if dim is None:
+        dim = list(range(in1.ndim))
 
     mx_specs = apply_mx_specs(mx_specs)
     return SIMDReduceSum.apply(in1, dim, keepdim, mx_specs)
 
 
-def simd_reduce_mean(in1, dim, keepdim=False, mx_specs=None):
+def simd_reduce_mean(in1, dim=None, keepdim=False, mx_specs=None):
     mx_assert_test(mx_specs)
     if mx_specs is None:
-        return torch_mean(in1, dim, keepdim=keepdim)
+        if dim is None:
+            return torch_sum(in1)
+        else:
+            return torch_mean(in1, dim, keepdim=keepdim)
+
+    if dim is None:
+        dim = list(range(in1.ndim))
 
     mx_specs = apply_mx_specs(mx_specs)
 

--- a/mx/tests/test_simd.py
+++ b/mx/tests/test_simd.py
@@ -133,7 +133,7 @@ def test_const(f1, f2, quantize_backprop, device, custom_cuda):
     (torch.sum,     simd_reduce_sum),
     (torch.mean,    simd_reduce_mean),
 ])
-@pytest.mark.parametrize("dim", [[0], [1], [-1], [0,-1], [0,1,2]])
+@pytest.mark.parametrize("dim", [None, [0], [1], [-1], [0,-1], [0,1,2]])
 @pytest.mark.parametrize("quantize_backprop", [False, True])
 @pytest.mark.parametrize("device, custom_cuda", DEVICE__CUSTOM_CUDA)
 def test_simd_reduce(f1, f2, dim, quantize_backprop,
@@ -154,12 +154,18 @@ def test_simd_reduce(f1, f2, dim, quantize_backprop,
     x2 = torch.tensor(_x, dtype=torch.float32, device=device,
                       requires_grad=True)
 
-    q1 = f1(x1, dim=dim)
+    if dim is None:
+        q1 = f1(x1)
+    else:
+        q1 = f1(x1, dim=dim)
     loss1 = (q1**2).mean().sqrt()
     loss1.backward()
     torch.cuda.synchronize()
 
-    q2 = f2(x2, dim=dim, mx_specs=mx_specs)
+    if dim is None:
+        q2 = f2(x2, mx_specs=mx_specs)
+    else:
+        q2 = f2(x2, dim=dim, mx_specs=mx_specs)
     loss2 = (q2**2).mean().sqrt()
     loss2.backward()
     torch.cuda.synchronize()


### PR DESCRIPTION
torch.sum (and similar functions) have two versions, one with a dim argument, and one without. This update should allow simd_reduce_sum/mean to support both. Previously only the with-dim version was supported.

Should fix #18 